### PR TITLE
Separate changelog from README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+## Changelog
+### v1.1.4
+- Added Malayalam translation
+- Added Piratenpad server
+
+### v1.1.3
+- Added French translation
+- Fixed a bug that caused the app to crash in some devices
+
+### v1.1.2
+- Removed unused permissions
+- Added Etherpad.net server
+
+### v1.1.1
+- Added German translation
+- Added Japanese translation
+
+### v1.1
+- Added spanish and catalan translation
+- Ready for a beta release
+
+### v1.0
+- Now documents can be classified in groups
+- Pads will by default appear in the "Unclassified" group
+- Groups can be added and deleted
+- Pads can be moved to groups in bulk
+- Design improvements
+- Security: Protected from undesired hosts to run java methods from javascript (disables some tracking too).
+- A hosts whitelist was added. Supports "*" wildcard for subdomains.
+- Improved compatibility with older Android versions (not lower than SDK 14)
+
+### v0.3
+- Added a parameter to count the times a pad was accessed
+- Added a loading animation
+- Improved stability issues
+- Landscape orientation is not forced anymore
+- Pad names can't be free strings now
+- Fixed minor bugs
+
+### v0.2
+- Added a view with pad data
+- The "last used date" parameter is updated correctly
+
+### v0.1
+- Added multiple-server support
+- Just commit

--- a/README.md
+++ b/README.md
@@ -7,65 +7,15 @@ Padland is a tool to manage, share, remember and read collaborative documents ba
 - More translations (volunteers?) 
 
 ## Current version
-1.1.4
-
-## Changelog
-### v1.1.4
-- Added Malayalam translation
-- Added Piratenpad server
-
-### v1.1.3
-- Added French translation
-- Fixed a bug that caused the app to crash in some devices
-
-### v1.1.2
-- Removed unused permissions
-- Added Etherpad.net server
-
-### v1.1.1
-- Added German translation
-- Added Japanese translation
-
-### v1.1
-- Added spanish and catalan translation
-- Ready for a beta release
-
-### v1.0
-- Now documents can be classified in groups
-- Pads will by default appear in the "Unclassified" group
-- Groups can be added and deleted
-- Pads can be moved to groups in bulk
-- Design improvements
-- Security: Protected from undesired hosts to run java methods from javascript (disables some tracking too).
-- A hosts whitelist was added. Supports "*" wildcard for subdomains.
-- Improved compatibility with older Android versions (not lower than SDK 14)
-
-### v0.3
-- Added a parameter to count the times a pad was accessed
-- Added a loading animation
-- Improved stability issues
-- Landscape orientation is not forced anymore
-- Pad names can't be free strings now
-- Fixed minor bugs
-
-### v0.2
-- Added a view with pad data
-- The "last used date" parameter is updated correctly
-
-### v0.1
-- Added multiple-server support
-- Just commit
+[1.1.4](CHANGELOG.md)
 
 ## Technology
 Etherpad depends on:
 - jQuery
 - etherpad-lite-jquery-plugin
 
-
-### License
-----
+## License
 Apache
-
 
 
 [Etherpad]:http://etherpad.org/


### PR DESCRIPTION
I separated changelog from README in order to make a list in another file so it will grow more and more without creating confusion in main file README.

The new page can be linked directly in F-Droid too.