### PR TITLE
Fix the forgotten versionname

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         applicationId "com.mikifus.padland"
         minSdkVersion 14
         targetSdkVersion 27
-        versionName '1.4-beta'
+        versionName '1.4'
         versionCode 17
         multiDexEnabled true
 //        vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
...so F-Droid can build

/LE: on a second thought, the Tag already points to the wrong commit, not sure it will help F-Droid ( [I've worked around it](https://gitlab.com/fdroid/fdroiddata/merge_requests/3473/diffs) ), but at least for consistency.